### PR TITLE
Issue#17 - UTF-encoding for JSON input

### DIFF
--- a/src/main/java/facades/CountryFacade.java
+++ b/src/main/java/facades/CountryFacade.java
@@ -110,7 +110,7 @@ public class CountryFacade {
             connection.setRequestMethod("GET");
             connection.setRequestProperty("Accept", "application/json;charset=UTF-8");
             connection.setRequestProperty("user-agent", "Application");
-            try (Scanner scan = new Scanner(connection.getInputStream())) {
+            try (Scanner scan = new Scanner(connection.getInputStream(), "UTF-8")) {
                 String response = "";
                 while (scan.hasNext()) {
                     response += scan.nextLine();

--- a/src/main/java/utils/APIUtil.java
+++ b/src/main/java/utils/APIUtil.java
@@ -100,7 +100,7 @@ public class APIUtil {
             connection.setRequestMethod("GET");
             connection.setRequestProperty("Accept", "application/json;charset=UTF-8");
             connection.setRequestProperty("user-agent", "Application");
-            try (Scanner scan = new Scanner(connection.getInputStream())) {
+            try (Scanner scan = new Scanner(connection.getInputStream(), "UTF-8")) {
                 String response = "";
                 while (scan.hasNext()) {
                     response += scan.nextLine();


### PR DESCRIPTION
## Deprecated
### Fixed by #28 

See #17

Old result: https://pastebin.com/raw/5nn7Vq2m
New result: https://pastebin.com/raw/mXkj0V8v

### Status
Much better, but not perfect. Search the new result for `?` to see errors.
16 total.
I think most, if not all, are this character: https://en.wikipedia.org/wiki/%C4%96 (funny how Wikipedia can't even encode it)

I don't know what to do. It shows that it is UTF-8 encoded.

Through my search there have been a few suggestions for this library:
https://github.com/albfernandez/juniversalchardet

### Other possible solutions
Maybe we should change the provided `getData`-method..
https://stackoverflow.com/a/21964051

(notes) **read through**
https://stackoverflow.com/questions/3995559/json-character-encoding
https://stackoverflow.com/questions/5729806/encode-string-to-utf-8


### What else I have tried
A lot. But some:
- Different kind of input readers (instead of Scanner) (https://stackoverflow.com/a/35446009)
- Different Encodings (ISO-8859-1)
- Forcing UTF-8 encoding on Strings through byte [] amongst others.