### PR TITLE
UTF-8 bugfix

### DIFF
--- a/src/main/java/facades/CountryFacade.java
+++ b/src/main/java/facades/CountryFacade.java
@@ -44,7 +44,7 @@ public class CountryFacade {
             countries = new ArrayList();
             instance.getEuropeanCountriesAndCities();
         }
-        System.out.println("FACADE.COUNTRIES:\n" + GSON.toJson(countries)); //Use if you want to see data
+        //System.out.println("FACADE.COUNTRIES:\n" + GSON.toJson(countries)); //Use if you want to see data
         return instance;
     }
 

--- a/src/main/java/facades/CountryFacade.java
+++ b/src/main/java/facades/CountryFacade.java
@@ -44,7 +44,7 @@ public class CountryFacade {
             countries = new ArrayList();
             instance.getEuropeanCountriesAndCities();
         }
-        //System.out.println("FACADE.COUNTRIES:\n" + GSON.toJson(countries)); //Use if you want to see data
+        System.out.println("FACADE.COUNTRIES:\n" + GSON.toJson(countries)); //Use if you want to see data
         return instance;
     }
 

--- a/src/main/java/facades/EventFacade.java
+++ b/src/main/java/facades/EventFacade.java
@@ -187,7 +187,7 @@ public class EventFacade {
             connection.setRequestProperty("Accept", "application/json;charset=UTF-8");
             connection.setRequestProperty("user-agent", "Application");
 
-            try (Scanner scan = new Scanner(connection.getInputStream())) {
+            try (Scanner scan = new Scanner(connection.getInputStream(), "UTF-8")) {
                 String response = "";
                 while (scan.hasNext()) {
                     response += scan.nextLine();

--- a/src/main/java/utils/APIUtil.java
+++ b/src/main/java/utils/APIUtil.java
@@ -100,10 +100,11 @@ public class APIUtil {
             connection.setRequestMethod("GET");
             connection.setRequestProperty("Accept", "application/json;charset=UTF-8");
             connection.setRequestProperty("user-agent", "Application");
-            try (Scanner scan = new Scanner(connection.getInputStream())) {
+            try (Scanner scan = new Scanner(connection.getInputStream(), "UTF-8")) {
                 String response = "";
                 while (scan.hasNext()) {
-                    response += new String (scan.nextLine().getBytes("UTF-8"));
+                     response += scan.nextLine();
+                    //response = response + new String (scan.nextLine().getBytes("UTF-8"));
                 }
                 JsonParser jsonParser = new JsonParser();
                 JsonElement jsonElement = jsonParser.parse(response);

--- a/src/main/java/utils/APIUtil.java
+++ b/src/main/java/utils/APIUtil.java
@@ -103,7 +103,7 @@ public class APIUtil {
             try (Scanner scan = new Scanner(connection.getInputStream())) {
                 String response = "";
                 while (scan.hasNext()) {
-                    response += scan.nextLine();
+                    response += new String (scan.nextLine().getBytes("UTF-8"));
                 }
                 JsonParser jsonParser = new JsonParser();
                 JsonElement jsonElement = jsonParser.parse(response);


### PR DESCRIPTION
The fix proposed by Rúni (#18 to add UTF-8 to scanners) is the correct fix to issue https://github.com/Hold-Krykke/3SemProject_BackEnd/issues/17.

This has been applied to all scanners and has seemingly fixed the issue. The terminal in Netbeans is uncooperative and doesn't show the correct encoding in System.out.println, but when the data is tested in the browser (chrome, via endpoint getCities()) the data is formatted correct. 

**Netbeans terminal**
![image](https://user-images.githubusercontent.com/35559774/70143039-e3bfe480-169a-11ea-9ad3-afb0444f8eda.png)


**Chrome browser**
![image](https://user-images.githubusercontent.com/35559774/70142924-a3606680-169a-11ea-9fed-8db79b666267.png)

Fixes #17 
